### PR TITLE
Rename defaultProfile from 'saml' to 'default'

### DIFF
--- a/controllers/aws_creds.go
+++ b/controllers/aws_creds.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultAmazonWebservicesURN = "urn:amazon:webservices"
-	defaultProfile              = "saml"
+	defaultProfile              = "default"
 )
 
 func formatAccount(config *configreader.Config, duration, login, role string) (*cfg.IDPAccount, error) {


### PR DESCRIPTION
As it simplifies downstream credentials propagation
and satisfies most of the use cases