### PR TITLE
Use pararametrized options to helm chart action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: docker/build-push-action@v1
       name: build/push - controller
       with:
@@ -23,13 +25,14 @@ jobs:
       run: |
         echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
         echo ::set-output name=semver::${GITHUB_REF#refs/tags/v}
-    - uses: k0da/helm-gh-pages-microservices@chart_version
+    - uses: k0da/helm-gh-pages-microservices@app_version
       with:
         access-token: ${{ secrets.REPO_TOKEN }}
         source-charts-folder: 'chart'
         destination-repo: absaoss/samlet
         destination-branch: gh-pages
-        helm-package-args: --version=${{ steps.tag.outputs.semver }} --app-version=${{ steps.tag.outputs.tag}}
+        helm-chart-version: ${{ steps.tag.outputs.semver }}
+        helm-app-version:  ${{ steps.tag.outputs.tag}}
     - name: Create single node k8s Kind Cluster
       uses: helm/kind-action@v1.0.0-rc.1
       with:


### PR DESCRIPTION
Switch to a new version of helm-gh-pages-microservices where chart
version and app-version are parametarized through inputs.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>