### PR TITLE
Do releases with goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,18 +8,28 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: docker/build-push-action@v1
-      name: build/push - controller
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+    - name: Login to Dockerhub
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: absaoss/samlet
-        dockerfile: Dockerfile
-        tag_with_ref: true
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: v2.4.1
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: compute-tag
       id: tag
       run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+project_name: absaoss/samlet
+before:
+  hooks:
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./main.go
+    binary: bin/manager
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+dockers:
+- image_templates:
+  - "{{ .ProjectName }}:{{ .Tag }}-amd64"
+  use_buildx: false
+  dockerfile: Dockerfile-amd64
+  build_flag_templates:
+  - "--platform=linux/amd64"
+- image_templates:
+  - "{{ .ProjectName }}:{{ .Tag }}-arm64"
+  use_buildx: false
+  goarch: arm64
+  dockerfile: Dockerfile-arm64
+  build_flag_templates:
+  - "--platform=linux/arm64"
+docker_manifests:
+  - name_template: "{{ .ProjectName }}:{{ .Tag }}"
+    image_templates:
+    - "{{ .ProjectName }}:{{ .Tag }}-amd64"
+    - "{{ .ProjectName }}:{{ .Tag }}-arm64"
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+release:
+  draft: true

--- a/Dockerfile-amd64
+++ b/Dockerfile-amd64
@@ -1,0 +1,8 @@
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot-amd64
+WORKDIR /
+COPY manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]

--- a/Dockerfile-arm64
+++ b/Dockerfile-arm64
@@ -1,0 +1,8 @@
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot-arm64
+WORKDIR /
+COPY manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
* Add .goreleaser.yaml
* Replace docker build action with docker login as docker builds
  are done by goreleaser
* Add arm64 support
* Add Docker file for each architecture

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>