### PR TITLE
Rename manager to samlet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ deploy: manifests kustomize
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role paths="./..." output:crd:artifacts:config=chart/samlet/templates
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=samlet-role paths="./..." output:crd:artifacts:config=chart/samlet/templates
 
 # Run go fmt against code
 fmt:

--- a/chart/samlet/templates/role.yaml
+++ b/chart/samlet/templates/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: samlet-role
 rules:
 - apiGroups:
   - ""

--- a/chart/samlet/templates/role_binding.yaml
+++ b/chart/samlet/templates/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: samlet-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: samlet-role
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
Manager is too wide and could clash another controllers created with
operator SDK

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>